### PR TITLE
Add simulation class for tracking trades

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from strategies.macd_strategy_trailing import apply_macd_strategy
 from strategies.bollinger_strategy_trailing import apply_bollinger_strategy
 from strategies.ma_cross_strategy_trailing import apply_ma_cross_strategy
 from strategies.custom_strategy_trailing import apply_custom_strategy
-from services.simulation import simulate_order
+from services.simulation import Simulation
 from services.logger import log_trade
 from settings import CHECK_INTERVAL_SECONDS, SYMBOL, TIMEFRAME
 
@@ -16,6 +16,8 @@ def select_best_timeframe():
 if __name__ == "__main__":
     current_timeframe = select_best_timeframe()
     print(f"\n[INFO] Using timeframe: {current_timeframe}\n")
+
+    simulation = Simulation()
 
     strategies = {
         "RSI": apply_rsi_strategy,
@@ -36,7 +38,7 @@ if __name__ == "__main__":
                 print(f"[{name}] Signal: {signal or '-'} | Value: {round(value, 2)} | Price: {price}")
                 log_trade(timestamp, SYMBOL, current_timeframe, value, price, signal, strategy_name=name)
                 if signal:
-                    simulate_order(signal, price)
+                    simulation.place_order(signal, price)
 
             time.sleep(CHECK_INTERVAL_SECONDS)
         except Exception as e:

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -1,2 +1,62 @@
-def simulate_order(signal, price):
-    print(f"[SIMULATION] {signal} at price: {price}")
+import csv
+import os
+from datetime import datetime
+
+
+class Simulation:
+    """Simple trading account simulation."""
+
+    def __init__(self, initial_balance: float = 0.0, log_dir: str = "logs",
+                 log_file: str = "simulation_log.csv") -> None:
+        self.balance = initial_balance
+        self.position = None  # holds entry price when in position
+        self.trade_history = []
+        self.log_dir = log_dir
+        self.log_file = os.path.join(log_dir, log_file)
+        os.makedirs(self.log_dir, exist_ok=True)
+        self._init_log_file()
+
+    def _init_log_file(self) -> None:
+        if not os.path.exists(self.log_file):
+            with open(self.log_file, "w", newline="", encoding="utf-8") as f:
+                writer = csv.writer(f)
+                writer.writerow(["timestamp", "signal", "price", "balance", "profit"])
+
+    def place_order(self, signal: str, price: float) -> None:
+        """Execute an order and update account state."""
+        if signal not in {"BUY", "SELL"}:
+            return
+
+        timestamp = datetime.utcnow().isoformat()
+        profit = 0.0
+
+        if signal == "BUY" and self.position is None:
+            self.position = price
+            self.trade_history.append({"timestamp": timestamp, "signal": "BUY", "price": price})
+        elif signal == "SELL" and self.position is not None:
+            profit = price - self.position
+            self.balance += profit
+            self.trade_history.append({
+                "timestamp": timestamp,
+                "signal": "SELL",
+                "price": price,
+                "profit": profit,
+            })
+            self.position = None
+        else:
+            return
+
+        with open(self.log_file, "a", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow([timestamp, signal, round(price, 2), round(self.balance, 2), round(profit, 2)])
+
+        print(f"[SIMULATION] {signal} at {price} | Balance: {self.balance:.2f}")
+
+    def get_summary(self) -> dict:
+        """Return a summary of the account state."""
+        open_pos = {"entry_price": self.position} if self.position is not None else None
+        return {
+            "balance": self.balance,
+            "open_position": open_pos,
+            "trade_count": len(self.trade_history),
+        }


### PR DESCRIPTION
## Summary
- create a `Simulation` class that records position and balance
- log each simulated trade to `logs/simulation_log.csv`
- use the new class in `main.py` so trades update the simulated account

## Testing
- `python -m py_compile services/simulation.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6878069d9f90832e8d7d9b8c3f19c908