### PR TITLE
Update trailing strategies return signature

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
             timestamp = df.iloc[-1]['timestamp']
 
             for name, strategy in strategies.items():
-                signal, value = strategy(df.copy())
+                signal, value, *_ = strategy(df.copy())
                 print(f"[{name}] Signal: {signal or '-'} | Value: {round(value, 2)} | Price: {price}")
                 log_trade(timestamp, SYMBOL, current_timeframe, value, price, signal, strategy_name=name)
                 if signal:

--- a/strategies/bollinger_strategy_trailing.py
+++ b/strategies/bollinger_strategy_trailing.py
@@ -1,7 +1,9 @@
 import pandas as pd
 import ta
 
-def apply_bollinger_strategy(df, trailing_pct=0.015):
+
+def apply_bollinger_strategy(df, trailing_pct=0.015, return_df=False):
+    """Apply Bollinger Bands strategy with trailing stop."""
     bb = ta.volatility.BollingerBands(close=df['price'], window=20, window_dev=2)
     df['bb_upper'] = bb.bollinger_hband()
     df['bb_lower'] = bb.bollinger_lband()
@@ -36,4 +38,15 @@ def apply_bollinger_strategy(df, trailing_pct=0.015):
                 signals.append({'timestamp': timestamp, 'signal': 'SELL', 'price': price, 'value': upper})
                 position = None
 
-    return pd.DataFrame(signals)
+    signals_df = pd.DataFrame(signals)
+
+    latest_signal = None
+    if not signals_df.empty and signals_df.iloc[-1]['timestamp'] == df.index[-1]:
+        latest_signal = signals_df.iloc[-1]['signal']
+
+    latest_value = df['price'].iloc[-1]
+
+    if return_df:
+        return latest_signal, latest_value, signals_df
+
+    return latest_signal, latest_value

--- a/strategies/custom_strategy_trailing.py
+++ b/strategies/custom_strategy_trailing.py
@@ -1,7 +1,9 @@
 import pandas as pd
 import ta
 
-def apply_custom_strategy(df, trailing_pct=0.015):
+
+def apply_custom_strategy(df, trailing_pct=0.015, return_df=False):
+    """Custom RSI/price momentum strategy with trailing stop."""
     df['rsi'] = ta.momentum.RSIIndicator(close=df['price'], window=14).rsi()
     df['low_20'] = df['price'].rolling(window=20).min()
     df.dropna(inplace=True)
@@ -37,4 +39,15 @@ def apply_custom_strategy(df, trailing_pct=0.015):
                 signals.append({'timestamp': timestamp, 'signal': 'SELL', 'price': price, 'value': rsi})
                 position = None
 
-    return pd.DataFrame(signals)
+    signals_df = pd.DataFrame(signals)
+
+    latest_signal = None
+    if not signals_df.empty and signals_df.iloc[-1]['timestamp'] == df.index[-1]:
+        latest_signal = signals_df.iloc[-1]['signal']
+
+    latest_value = df['rsi'].iloc[-1]
+
+    if return_df:
+        return latest_signal, latest_value, signals_df
+
+    return latest_signal, latest_value

--- a/strategies/ma_cross_strategy_trailing.py
+++ b/strategies/ma_cross_strategy_trailing.py
@@ -1,6 +1,8 @@
 import pandas as pd
 
-def apply_ma_cross_strategy(df, trailing_pct=0.015):
+
+def apply_ma_cross_strategy(df, trailing_pct=0.015, return_df=False):
+    """Moving Average cross strategy with trailing stop."""
     df['ma_short'] = df['price'].rolling(window=5).mean()
     df['ma_long'] = df['price'].rolling(window=20).mean()
     df.dropna(inplace=True)
@@ -34,4 +36,15 @@ def apply_ma_cross_strategy(df, trailing_pct=0.015):
                 signals.append({'timestamp': timestamp, 'signal': 'SELL', 'price': price, 'value': short})
                 position = None
 
-    return pd.DataFrame(signals)
+    signals_df = pd.DataFrame(signals)
+
+    latest_signal = None
+    if not signals_df.empty and signals_df.iloc[-1]['timestamp'] == df.index[-1]:
+        latest_signal = signals_df.iloc[-1]['signal']
+
+    latest_value = df['ma_short'].iloc[-1]
+
+    if return_df:
+        return latest_signal, latest_value, signals_df
+
+    return latest_signal, latest_value

--- a/strategies/macd_strategy_trailing.py
+++ b/strategies/macd_strategy_trailing.py
@@ -1,7 +1,9 @@
 import pandas as pd
 import ta
 
-def apply_macd_strategy(df, trailing_pct=0.015):
+
+def apply_macd_strategy(df, trailing_pct=0.015, return_df=False):
+    """Apply MACD strategy with trailing stop."""
     macd = ta.trend.MACD(close=df['price'])
     df['macd'] = macd.macd()
     df['signal_line'] = macd.macd_signal()
@@ -35,4 +37,15 @@ def apply_macd_strategy(df, trailing_pct=0.015):
                 signals.append({'timestamp': timestamp, 'signal': 'SELL', 'price': price, 'value': macd_val})
                 position = None
 
-    return pd.DataFrame(signals)
+    signals_df = pd.DataFrame(signals)
+
+    latest_signal = None
+    if not signals_df.empty and signals_df.iloc[-1]['timestamp'] == df.index[-1]:
+        latest_signal = signals_df.iloc[-1]['signal']
+
+    latest_value = df['macd'].iloc[-1]
+
+    if return_df:
+        return latest_signal, latest_value, signals_df
+
+    return latest_signal, latest_value

--- a/strategies/rsi_strategy_trailing.py
+++ b/strategies/rsi_strategy_trailing.py
@@ -1,7 +1,26 @@
 import pandas as pd
 import ta
 
-def apply_rsi_strategy(df, trailing_pct=0.015):
+
+def apply_rsi_strategy(df, trailing_pct=0.015, return_df=False):
+    """Apply RSI strategy with trailing stop.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame containing at least a ``price`` column.
+    trailing_pct : float, optional
+        Trailing stop percentage.
+    return_df : bool, optional
+        When ``True`` also return the dataframe of generated signals.
+
+    Returns
+    -------
+    tuple
+        ``(signal, value)`` or ``(signal, value, signals_df)`` when
+        ``return_df`` is ``True``.
+    """
+
     df['rsi'] = ta.momentum.RSIIndicator(close=df['price'], window=14).rsi()
     df.dropna(inplace=True)
 
@@ -32,4 +51,15 @@ def apply_rsi_strategy(df, trailing_pct=0.015):
                 signals.append({'timestamp': timestamp, 'signal': 'SELL', 'price': price, 'value': rsi})
                 position = None
 
-    return pd.DataFrame(signals)
+    signals_df = pd.DataFrame(signals)
+
+    latest_signal = None
+    if not signals_df.empty and signals_df.iloc[-1]['timestamp'] == df.index[-1]:
+        latest_signal = signals_df.iloc[-1]['signal']
+
+    latest_value = df['rsi'].iloc[-1]
+
+    if return_df:
+        return latest_signal, latest_value, signals_df
+
+    return latest_signal, latest_value


### PR DESCRIPTION
## Summary
- return latest signal/value from trailing strategies and keep optional dataframe
- update main loop to handle new return signature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878069e3fb4832ebf29ef2761abb26a