### PR TITLE
Add backtesting service and merge with updated simulation

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -1,0 +1,25 @@
+from services.backtest_service import run_backtest
+from strategies.rsi_strategy_trailing import apply_rsi_strategy
+from strategies.macd_strategy_trailing import apply_macd_strategy
+from strategies.bollinger_strategy_trailing import apply_bollinger_strategy
+from strategies.ma_cross_strategy_trailing import apply_ma_cross_strategy
+from strategies.custom_strategy_trailing import apply_custom_strategy
+
+
+if __name__ == "__main__":
+    strategies = {
+        "RSI": apply_rsi_strategy,
+        "MACD": apply_macd_strategy,
+        "BOLLINGER": apply_bollinger_strategy,
+        "MA_CROSS": apply_ma_cross_strategy,
+        "CUSTOM": apply_custom_strategy,
+    }
+
+    metrics = run_backtest(strategies, symbol="BTC/USDT", timeframe="5m", limit=500)
+    for name, result in metrics.items():
+        total = result["total_return"] * 100
+        win_rate = result["win_rate"] * 100
+        drawdown = result["drawdown"] * 100
+        print(
+            f"{name}: Return {total:.2f}% | Win Rate {win_rate:.2f}% | Max Drawdown {drawdown:.2f}%"
+        )

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from strategies.macd_strategy_trailing import apply_macd_strategy
 from strategies.bollinger_strategy_trailing import apply_bollinger_strategy
 from strategies.ma_cross_strategy_trailing import apply_ma_cross_strategy
 from strategies.custom_strategy_trailing import apply_custom_strategy
-from services.simulation import simulate_order
+from services.simulation import Simulation
 from services.logger import log_trade
 from settings import CHECK_INTERVAL_SECONDS, SYMBOL, TIMEFRAME
 
@@ -16,6 +16,8 @@ def select_best_timeframe():
 if __name__ == "__main__":
     current_timeframe = select_best_timeframe()
     print(f"\n[INFO] Using timeframe: {current_timeframe}\n")
+
+    simulation = Simulation()
 
     strategies = {
         "RSI": apply_rsi_strategy,
@@ -36,7 +38,7 @@ if __name__ == "__main__":
                 print(f"[{name}] Signal: {signal or '-'} | Value: {round(value, 2)} | Price: {price}")
                 log_trade(timestamp, SYMBOL, current_timeframe, value, price, signal, strategy_name=name)
                 if signal:
-                    simulate_order(signal, price)
+                    simulation.place_order(signal, price)
 
             time.sleep(CHECK_INTERVAL_SECONDS)
         except Exception as e:

--- a/services/backtest_service.py
+++ b/services/backtest_service.py
@@ -1,0 +1,72 @@
+import pandas as pd
+from typing import Callable, Dict
+
+from services.data_service import fetch_ohlcv
+from services.simulation import BacktestSimulation
+
+
+def run_backtest(
+    strategies: Dict[str, Callable[[pd.DataFrame], pd.DataFrame]],
+    symbol: str = "BTC/USDT",
+    timeframe: str = "5m",
+    limit: int = 500,
+    initial_balance: float = 1000.0,
+) -> Dict[str, Dict[str, float]]:
+    """Run backtest for provided strategies.
+
+    Parameters
+    ----------
+    strategies: dict
+        Mapping of strategy name to strategy function returning a DataFrame of
+        signals with columns ["timestamp", "signal", "price", "value"].
+    symbol: str
+        Market symbol to fetch OHLCV data for.
+    timeframe: str
+        Timeframe to request from exchange.
+    limit: int
+        Number of bars to fetch.
+    initial_balance: float
+        Starting balance for each strategy simulation.
+
+    Returns
+    -------
+    dict
+        Metrics for each strategy containing total_return, win_rate and
+        max_drawdown.
+    """
+    df = fetch_ohlcv(symbol=symbol, timeframe=timeframe, limit=limit)
+    df = df.rename(columns={"close": "price"}).set_index("timestamp")
+
+    # Pre-compute all strategy signals on the full dataframe
+    strategy_signals = {}
+    simulations = {}
+    for name, strat in strategies.items():
+        signals = strat(df.copy())
+        if not isinstance(signals, pd.DataFrame) or signals.empty:
+            # normal strategies might return tuple (signal, value)
+            signals = pd.DataFrame([], columns=["timestamp", "signal", "price", "value"])
+        signals = signals.set_index("timestamp") if not signals.empty else signals
+        strategy_signals[name] = signals
+        simulations[name] = BacktestSimulation(initial_balance=initial_balance)
+
+    # Iterate through each bar and feed signals to simulations
+    for ts, row in df.iterrows():
+        price = row["price"]
+        for name, signals in strategy_signals.items():
+            if not signals.empty and ts in signals.index:
+                signal = signals.loc[ts]["signal"]
+                simulations[name].process_signal(signal, price)
+
+    # Close any open position at final price
+    final_price = df.iloc[-1]["price"]
+    metrics = {}
+    for name, sim in simulations.items():
+        sim.close_final(final_price)
+        total_ret, win_rate, drawdown = sim.get_metrics()
+        metrics[name] = {
+            "total_return": total_ret,
+            "win_rate": win_rate,
+            "drawdown": drawdown,
+        }
+    return metrics
+

--- a/services/simulation.py
+++ b/services/simulation.py
@@ -1,2 +1,107 @@
-def simulate_order(signal, price):
+import csv
+import os
+from datetime import datetime
+from typing import List
+
+
+class Simulation:
+    """Simple trading account simulation."""
+
+    def __init__(self, initial_balance: float = 0.0, log_dir: str = "logs", log_file: str = "simulation_log.csv") -> None:
+        self.balance = initial_balance
+        self.position = None  # holds entry price when in position
+        self.trade_history = []
+        self.log_dir = log_dir
+        self.log_file = os.path.join(log_dir, log_file)
+        os.makedirs(self.log_dir, exist_ok=True)
+        self._init_log_file()
+
+    def _init_log_file(self) -> None:
+        if not os.path.exists(self.log_file):
+            with open(self.log_file, "w", newline="", encoding="utf-8") as f:
+                writer = csv.writer(f)
+                writer.writerow(["timestamp", "signal", "price", "balance", "profit"])
+
+    def place_order(self, signal: str, price: float) -> None:
+        """Execute an order and update account state."""
+        if signal not in {"BUY", "SELL"}:
+            return
+
+        timestamp = datetime.utcnow().isoformat()
+        profit = 0.0
+
+        if signal == "BUY" and self.position is None:
+            self.position = price
+            self.trade_history.append({"timestamp": timestamp, "signal": "BUY", "price": price})
+        elif signal == "SELL" and self.position is not None:
+            profit = price - self.position
+            self.balance += profit
+            self.trade_history.append({
+                "timestamp": timestamp,
+                "signal": "SELL",
+                "price": price,
+                "profit": profit,
+            })
+            self.position = None
+        else:
+            return
+
+        with open(self.log_file, "a", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow([timestamp, signal, round(price, 2), round(self.balance, 2), round(profit, 2)])
+
+        print(f"[SIMULATION] {signal} at {price} | Balance: {self.balance:.2f}")
+
+    def get_summary(self) -> dict:
+        """Return a summary of the account state."""
+        open_pos = {"entry_price": self.position} if self.position is not None else None
+        return {
+            "balance": self.balance,
+            "open_position": open_pos,
+            "trade_count": len(self.trade_history),
+        }
+
+
+class BacktestSimulation:
+    """Simulation engine used for strategy backtesting."""
+
+    def __init__(self, initial_balance: float = 1000.0) -> None:
+        self.initial_balance = initial_balance
+        self.balance = initial_balance
+        self.position_price = None
+        self.trades: List[float] = []
+        self.equity_curve: List[float] = [initial_balance]
+
+    def process_signal(self, signal: str, price: float) -> None:
+        """Process BUY/SELL signal at given price."""
+        if signal == "BUY" and self.position_price is None:
+            self.position_price = price
+        elif signal == "SELL" and self.position_price is not None:
+            ret = price / self.position_price - 1
+            self.balance *= 1 + ret
+            self.trades.append(ret)
+            self.equity_curve.append(self.balance)
+            self.position_price = None
+
+    def close_final(self, price: float) -> None:
+        if self.position_price is not None:
+            self.process_signal("SELL", price)
+
+    def get_metrics(self) -> tuple[float, float, float]:
+        total_return = self.balance / self.initial_balance - 1
+        win_trades = [t for t in self.trades if t > 0]
+        win_rate = len(win_trades) / len(self.trades) if self.trades else 0.0
+        peak = self.equity_curve[0]
+        max_dd = 0.0
+        for val in self.equity_curve:
+            if val > peak:
+                peak = val
+            drawdown = (peak - val) / peak
+            if drawdown > max_dd:
+                max_dd = drawdown
+        return total_return, win_rate, max_dd
+
+
+def simulate_order(signal: str, price: float) -> None:
+    """Backward compatibility helper."""
     print(f"[SIMULATION] {signal} at price: {price}")


### PR DESCRIPTION
## Summary
- merge recent master changes
- introduce `BacktestSimulation` alongside original `Simulation`
- update backtesting service to use `BacktestSimulation`
- adjust main script to use account `Simulation`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6878069de3c0832ea5bb87505a6d0dbb