### PR TITLE
Fix price column KeyError

### DIFF
--- a/services/data_service.py
+++ b/services/data_service.py
@@ -18,6 +18,9 @@ def fetch_ohlcv(symbol="BTC/USDT", timeframe="5m", limit=100):
     ohlcv = binance.fetch_ohlcv(symbol, timeframe, limit=limit)
     df = pd.DataFrame(ohlcv, columns=['timestamp', 'open', 'high', 'low', 'close', 'volume'])
     df['timestamp'] = pd.to_datetime(df['timestamp'], unit='ms')
+    # many strategy modules expect a ``price`` column which mirrors ``close``.
+    # add it here to avoid ``KeyError: 'price'`` during strategy execution.
+    df['price'] = df['close']
     return df
 
 def get_available_timeframes():

--- a/strategies/bollinger_strategy_trailing.py
+++ b/strategies/bollinger_strategy_trailing.py
@@ -4,6 +4,10 @@ import ta
 
 def apply_bollinger_strategy(df, trailing_pct=0.015, return_df=False):
     """Apply Bollinger Bands strategy with trailing stop."""
+    df = df.copy()
+    if 'price' not in df.columns:
+        df['price'] = df['close']
+
     bb = ta.volatility.BollingerBands(close=df['price'], window=20, window_dev=2)
     df['bb_upper'] = bb.bollinger_hband()
     df['bb_lower'] = bb.bollinger_lband()

--- a/strategies/custom_strategy_trailing.py
+++ b/strategies/custom_strategy_trailing.py
@@ -4,6 +4,10 @@ import ta
 
 def apply_custom_strategy(df, trailing_pct=0.015, return_df=False):
     """Custom RSI/price momentum strategy with trailing stop."""
+    df = df.copy()
+    if 'price' not in df.columns:
+        df['price'] = df['close']
+
     df['rsi'] = ta.momentum.RSIIndicator(close=df['price'], window=14).rsi()
     df['low_20'] = df['price'].rolling(window=20).min()
     df.dropna(inplace=True)

--- a/strategies/ma_cross_strategy_trailing.py
+++ b/strategies/ma_cross_strategy_trailing.py
@@ -3,6 +3,10 @@ import pandas as pd
 
 def apply_ma_cross_strategy(df, trailing_pct=0.015, return_df=False):
     """Moving Average cross strategy with trailing stop."""
+    df = df.copy()
+    if 'price' not in df.columns:
+        df['price'] = df['close']
+
     df['ma_short'] = df['price'].rolling(window=5).mean()
     df['ma_long'] = df['price'].rolling(window=20).mean()
     df.dropna(inplace=True)

--- a/strategies/macd_strategy_trailing.py
+++ b/strategies/macd_strategy_trailing.py
@@ -4,6 +4,10 @@ import ta
 
 def apply_macd_strategy(df, trailing_pct=0.015, return_df=False):
     """Apply MACD strategy with trailing stop."""
+    df = df.copy()
+    if 'price' not in df.columns:
+        df['price'] = df['close']
+
     macd = ta.trend.MACD(close=df['price'])
     df['macd'] = macd.macd()
     df['signal_line'] = macd.macd_signal()

--- a/strategies/rsi_strategy_trailing.py
+++ b/strategies/rsi_strategy_trailing.py
@@ -21,6 +21,10 @@ def apply_rsi_strategy(df, trailing_pct=0.015, return_df=False):
         ``return_df`` is ``True``.
     """
 
+    df = df.copy()
+    if 'price' not in df.columns:
+        df['price'] = df['close']
+
     df['rsi'] = ta.momentum.RSIIndicator(close=df['price'], window=14).rsi()
     df.dropna(inplace=True)
 


### PR DESCRIPTION
## Summary
- ensure `fetch_ohlcv` creates a `price` column so strategies relying on it do not fail
- add fallback logic in trailing strategies to use `close` when `price` missing

## Testing
- `python3 -m py_compile main.py services/data_service.py strategies/*.py`
- `pip install ccxt` *(fails: proxy / no internet)*

------
https://chatgpt.com/codex/tasks/task_e_687809501ea8832eacc42499d5355414